### PR TITLE
Improve CPU quick config and make memory device-selectable

### DIFF
--- a/configs/cpu_quick.yaml
+++ b/configs/cpu_quick.yaml
@@ -1,8 +1,39 @@
+seed: 1337
+
 data:
-  train_size: 512
+  decouple_kv: true
+  length: 128
+  n_pairs: 1
+  num_values: 32
+  train_size: 384
   val_size: 64
+  vocab_extra: 32
+
+model:
+  emb_dim: 48
+  hid_dim: 96
+  mem_dim: 192
+
+memory:
+  n_slots: 128
+  k_top: 8
+  device: cpu  # set to "auto" or a device string (e.g., "cuda") to follow the trainer
+
 train:
-  epochs: 3
   batch_size: 16
+  lr: 0.003
+  wd: 0.0
+  epochs: 3
+  lr_after_warm_factor: 0.5
+
 emma:
-  deq_max_iter: 6
+  deq_max_iter: 4
+  oracle_write: false
+  warm_start_epochs: 1
+  mem_into_deq: false
+  logit_scale_max: 5.0
+
+loss:
+  lambda_pred_ce: 0.2
+  lambda_write_cos: 0.1
+  lambda_write_nce: 0.0

--- a/emma/train.py
+++ b/emma/train.py
@@ -765,6 +765,12 @@ def main():
             cleanup_blend_raw = cleanup_blend_clean = None
     write_norm_clip = memory_cfg.get('write_norm_clip', None)
 
+    memory_device_cfg = memory_cfg.get('device', 'cpu')
+    if isinstance(memory_device_cfg, str) and memory_device_cfg.lower() == 'auto':
+        memory_device = device
+    else:
+        memory_device = memory_device_cfg
+
     model = EMMA(
         vocab_size=vocab_size,
         warm_start_epochs=cfg_emma.get('warm_start_epochs', 0),
@@ -788,6 +794,7 @@ def main():
         cleanup_blend_raw=cleanup_blend_raw,
         cleanup_blend_clean=cleanup_blend_clean,
         write_norm_clip=write_norm_clip,
+        memory_device=memory_device,
     )
     model.to(device)
 


### PR DESCRIPTION
## Summary
- expand the `cpu_quick` YAML so it carries all required dataset/model knobs and can run without overrides
- add configurable memory device support to `VSAMemory`/`EMMA` so associative memory can follow CPU, CUDA, or auto devices
- plumb the memory device option through the trainer for config control while keeping legacy defaults unchanged

## Testing
- `python scripts/run_training.py --config configs/cpu_quick.yaml --device cpu`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d5e797f9a8832b8b7b63be46c919f5